### PR TITLE
Adapt extras scripts to some recent changes in ci-framework

### DIFF
--- a/az0/nncp.yaml
+++ b/az0/nncp.yaml
@@ -87,10 +87,7 @@ spec:
       state: up
       type: linux-bridge
     routes:
-      config:
-      - destination: 0.0.0.0/0
-        next-hop-address: 192.168.122.1
-        next-hop-interface: ospbr
+      config: []
   nodeSelector:
     kubernetes.io/hostname: master-0
     node-role.kubernetes.io/worker: ""
@@ -184,10 +181,7 @@ spec:
       state: up
       type: linux-bridge
     routes:
-      config:
-      - destination: 0.0.0.0/0
-        next-hop-address: 192.168.122.1
-        next-hop-interface: ospbr
+      config: []
   nodeSelector:
     kubernetes.io/hostname: master-1
     node-role.kubernetes.io/worker: ""
@@ -281,10 +275,7 @@ spec:
       state: up
       type: linux-bridge
     routes:
-      config:
-      - destination: 0.0.0.0/0
-        next-hop-address: 192.168.122.1
-        next-hop-interface: ospbr
+      config: []
   nodeSelector:
     kubernetes.io/hostname: master-2
     node-role.kubernetes.io/worker: ""

--- a/extra/ceph.sh
+++ b/extra/ceph.sh
@@ -17,7 +17,7 @@ pushd $CIFMW
 export N=2
 echo -e "localhost ansible_connection=local\n[computes]" > inventory.yml
 for I in $(seq $START $((N+$START))); do
-    echo 192.168.122.${I} >> inventory.yml
+    echo 192.168.122.${I} ansible_ssh_private_key_file=/home/zuul/.ssh/id_cifw >> inventory.yml
 done
 export ANSIBLE_REMOTE_USER=zuul
 export ANSIBLE_SSH_PRIVATE_KEY=~/.ssh/id_cifw
@@ -30,6 +30,7 @@ if [ $? -gt 0 ]; then
 fi
 ln -fs ~/dcn/extra/ceph.yaml
 ln -fs ~/dcn/extra/$2
+# hci.yml must be copied from custom/hci.yaml of ci-framework
 ln -fs ~/hci.yaml
 ANSIBLE_GATHERING=implicit ansible-playbook playbooks/ceph.yml -e @hci.yaml -e @ceph.yaml -e @$2
 popd

--- a/extra/test.sh
+++ b/extra/test.sh
@@ -347,7 +347,7 @@ fi
 if [ $SNAP_MV -eq 1 ]; then
     # Create a new image on AZn containing a snapshot of
     # the instance created in the previous section.
-    openstack server image create --name cirros-snapshot vm1-pet
+    openstack server image create --name cirros-snapshot $VM_NAME
     sleep 5
     openstack image list
     openstack volume snapshot list


### PR DESCRIPTION
- There was a split edpm into deployment and nodeset stages in ci-framework[1] and architecture repo[2]
- Do not use "eval/e" option in yq command because yq available in pip does not have such option and the other yq defaults to eval option
- Drop the nncp ctlplane default route 192.168.122.1 (otherwise the deployment failed for me with: "The next hop interface of desired Route 'destination: 0.0.0.0/0 next-hop-interface: enp6s0 next-hop-address: 192.168.122.1' has been marked avs IPv4 disabled" It was dropped in ci-framework too[3]

[1] https://github.com/openstack-k8s-operators/ci-framework/commit/6f856db7e306d38e5ae056facea547f724485c15
[2] https://github.com/openstack-k8s-operators/architecture/commit/eca199600cd164fde4550a398794e9eb9c91fb76
[3] https://github.com/openstack-k8s-operators/ci-framework/commit/66277da980a5664413438f32c522739c6ede987a